### PR TITLE
Add support for a sending delay. Implemented for SQS

### DIFF
--- a/samples/OpenMessage.Samples.Core/Extensions.cs
+++ b/samples/OpenMessage.Samples.Core/Extensions.cs
@@ -1,4 +1,4 @@
-﻿using OpenMessage.Samples.Core.Services;
+using OpenMessage.Samples.Core.Services;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/samples/OpenMessage.Samples.Core/Services/ProducerService.cs
+++ b/samples/OpenMessage.Samples.Core/Services/ProducerService.cs
@@ -1,4 +1,4 @@
-﻿using AutoFixture;
+using AutoFixture;
 using Microsoft.Extensions.Hosting;
 using System;
 using System.Threading;

--- a/src/OpenMessage/ExtendedMessage{T}.cs
+++ b/src/OpenMessage/ExtendedMessage{T}.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,13 +7,16 @@ namespace OpenMessage
     /// <summary>
     /// Like a normal message, but supports properties and identification
     /// </summary>
-    public class ExtendedMessage<T> : Message<T>, ISupportProperties, ISupportIdentification
+    public class ExtendedMessage<T> : Message<T>, ISupportProperties, ISupportIdentification, ISupportSendDelay
     {
         /// <inheritDoc />
         public IEnumerable<KeyValuePair<string, string>> Properties { get; set; } = Enumerable.Empty<KeyValuePair<string, string>>();
 
         /// <inheritDoc />
         public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
+        /// <inheritDoc />
+        public TimeSpan SendDelay { get; set; } = TimeSpan.Zero;
 
         /// <summary>
         ///     Creates a new message

--- a/src/OpenMessage/ISupportSendDelay.cs
+++ b/src/OpenMessage/ISupportSendDelay.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace OpenMessage
+{
+    /// <summary>
+    ///     Indicates the message supports a send delay
+    /// </summary>
+    public interface ISupportSendDelay
+    {
+        /// <summary>
+        ///     How long to delay the send of the message. The value is limited by the maximum value allowed by the messaging protocol
+        /// </summary>
+        public TimeSpan SendDelay { get; set; }
+    }
+}


### PR DESCRIPTION
Added a new interface `ISupportSendDelay` to support a sending delay. 

- `ExtendedMessage` implements `ISupportSendDelay`
- Has only been implemented for SQS 