### PR TITLE
Fix Deserialization Bug

### DIFF
--- a/src/OpenMessage.AWS.SQS/SqsConsumer.cs
+++ b/src/OpenMessage.AWS.SQS/SqsConsumer.cs
@@ -91,7 +91,7 @@ namespace OpenMessage.AWS.SQS
                 }
                 catch (Exception e)
                 {
-                    // Swallow deserialization exception to prevent blocking the pipeline and processing of subsequent messages
+                    // Swallow deserialization exception to prevent blocking the pipeline and processing of subsequent messages.
                     _logger.LogError(e,$"Error deserializing message body. {e.Message}. {nameof(message.MessageId)}:{message.MessageId}. {nameof(message.MD5OfBody)}:{message.MD5OfBody}");
                 }
             }

--- a/tests/OpenMessage.Tests/Pipelines/BatcherTests.cs
+++ b/tests/OpenMessage.Tests/Pipelines/BatcherTests.cs
@@ -31,9 +31,9 @@ namespace OpenMessage.Tests.Pipelines
 
             Assert.Equal(1, _history.Count);
 
-            Assert.Equal(_batchSize - 1, _history.Single()
-                                                 .Count);
-            Assert.True(stopwatch.Elapsed >= _timeout);
+            Assert.Equal(_batchSize - 1, _history.Single().Count);
+
+            Assert.True(stopwatch.Elapsed.Add(TimeSpan.FromMilliseconds(5)) >= _timeout);
         }
 
         [Fact]
@@ -49,8 +49,8 @@ namespace OpenMessage.Tests.Pipelines
 
             Assert.Equal(1, _history.Count);
 
-            Assert.Equal(_batchSize, _history.Single()
-                                             .Count);
+            Assert.Equal(_batchSize, _history.Single().Count);
+
             Assert.True(stopwatch.Elapsed < _timeout);
         }
 


### PR DESCRIPTION
When an error occurs during deserialization of a message body it crashes the consumer. 

When the messages are again read from SQS the offending message is still at the front of the queue therefore the same exception happens. This effectively blocks the pipeline and stops any other messages from being processed.

The solution is to essentially ignore the offending message by catching the exception, which means it wont get handled . Eventually after its visibility view count has exceeded the max number it will be moved to the DLQ by SQS redrive policy.